### PR TITLE
Upgrading plugin tomcat7-maven-plugin and fix error when starting.

### DIFF
--- a/lightadmin-sandbox/pom.xml
+++ b/lightadmin-sandbox/pom.xml
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>org.apache.tomcat.maven</groupId>
                 <artifactId>tomcat7-maven-plugin</artifactId>
-                <version>2.1</version>
+                <version>2.2</version>
                 <configuration>
                     <port>${container.port}</port>
                     <uriEncoding>UTF-8</uriEncoding>


### PR DESCRIPTION
- The plugin tomcat7-maven-plugin version 2.1 use Apache Tomcat/7.0.37 and when init throws the Spring exception:
  java.lang.IllegalStateException: No suitable default
  RequestUpgradeStrategy found. Maybe is missing some dependencies.
- Upgrading to tomcat7-maven-plugin version 2.2 it will use Apache
  Tomcat/7.0.47 and run fine without exception.
