### PR TITLE
added version-numbers as comments for reference

### DIFF
--- a/lightadmin-core/pom.xml
+++ b/lightadmin-core/pom.xml
@@ -99,36 +99,49 @@
           http://docs.spring.io/platform/docs/1.1.2.RELEASE/reference/htmlsingle/#appendix-dependency-versions
         -->
 
+        <!-- Same Versions -->
+
         <spring.version>4.1.6.RELEASE</spring.version>
         <spring.security.version>3.2.7.RELEASE</spring.security.version>
-        <spring.data.jpa.version>1.8.0.RELEASE</spring.data.jpa.version> <!-- 1.7.2.RELEASE -->
-        <spring.data.rest.webmvc.version>2.3.0.RELEASE</spring.data.rest.webmvc.version> <!-- 2.2.2.RELEASE -->
-        <apache.tiles.version>2.2.2</apache.tiles.version> <!--3.0.5-->
-        <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version> <!--1.0.1.Final-->
         <hibernate-validator.version>5.1.3.Final</hibernate-validator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
-        <guava.version>18.0</guava.version> <!-- 17.0 -->
         <commons-lang3.version>3.3.2</commons-lang3.version>
-        <commons-collections4.version>4.0</commons-collections4.version> <!-- none -->
         <commons-fileupload.version>1.3.1</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
-        <imgscalr-lib.version>4.2</imgscalr-lib.version> <!-- none -->
-        <joda-time.version>2.3</joda-time.version> <!-- 2.5 -->
+        <jstl.version>1.2</jstl.version>
+        <javassist.version>3.18.1-GA</javassist.version>
+        <junit.version>4.11</junit.version>
+
+        <!-- LA  has Newer Versions -->
+
+        <spring.data.jpa.version>1.8.0.RELEASE</spring.data.jpa.version> <!-- 1.7.2.RELEASE -->
+        <spring.data.rest.webmvc.version>2.3.0.RELEASE</spring.data.rest.webmvc.version> <!-- 2.2.2.RELEASE -->
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version> <!-- 3.0.1 -->
         <javax.servlet.jsp-api.version>2.3.1</javax.servlet.jsp-api.version> <!-- 2.2.1 -->
-        <jstl.version>1.2</jstl.version>
-        <tika-core.version>1.4</tika-core.version> <!-- none -->
-        <ehcache-web.version>2.0.4</ehcache-web.version> <!-- none, only ehcache 2.8.5, ehcache-core 2.6.10 -->
-        <collections-generic.version>4.01</collections-generic.version><!-- none -->
-        <javassist.version>3.18.1-GA</javassist.version>
+        <guava.version>18.0</guava.version> <!-- 17.0 -->
+
+        <!-- LA has Older Version -->
+
+        <apache.tiles.version>2.2.2</apache.tiles.version> <!--3.0.5-->
+        <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version> <!--1.0.1.Final-->
+        <joda-time.version>2.3</joda-time.version> <!-- 2.5 -->
         <hibernate-entitymanager.version>4.3.6.Final</hibernate-entitymanager.version> <!-- 4.3.8.Final -->
-        <usertype.jadira.version>3.2.0.GA</usertype.jadira.version><!-- none -->
-        <joda-time.hibernate.version>1.3</joda-time.hibernate.version><!-- none -->
         <jackson.version>2.3.4</jackson.version> <!-- 2.4.5 -->
         <slf4j.version>1.7.7</slf4j.version> <!-- 1.7.11 -->
         <logback.version>1.1.2</logback.version> <!-- 1.1.3 -->
-        <junit.version>4.11</junit.version>
-        <easymock.version>3.2</easymock.version>
+
+
+        <!-- not included within spring-platform 1.1.2 -->
+        <commons-collections4.version>4.0</commons-collections4.version> <!-- none -->
+        <imgscalr-lib.version>4.2</imgscalr-lib.version> <!-- none -->
+        <tika-core.version>1.4</tika-core.version> <!-- none -->
+        <ehcache-web.version>2.0.4</ehcache-web.version> <!-- none, only ehcache 2.8.5, ehcache-core 2.6.10 -->
+        <collections-generic.version>4.01</collections-generic.version><!-- none -->
+        <usertype.jadira.version>3.2.0.GA</usertype.jadira.version><!-- none -->
+        <joda-time.hibernate.version>1.3</joda-time.hibernate.version><!-- none -->
+        <easymock.version>3.2</easymock.version><!-- none -->
+
+
     </properties>
 
     <prerequisites>

--- a/lightadmin-core/pom.xml
+++ b/lightadmin-core/pom.xml
@@ -93,34 +93,40 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
 
+        <!--
+          comparing versions to spring-platform 1.1.2, which is the current, and corresponds to current boot 1.2.3
+          no comment = same version. / "none" = not included in spring-platform
+          http://docs.spring.io/platform/docs/1.1.2.RELEASE/reference/htmlsingle/#appendix-dependency-versions
+        -->
+
         <spring.version>4.1.6.RELEASE</spring.version>
         <spring.security.version>3.2.7.RELEASE</spring.security.version>
-        <spring.data.jpa.version>1.8.0.RELEASE</spring.data.jpa.version>
-        <spring.data.rest.webmvc.version>2.3.0.RELEASE</spring.data.rest.webmvc.version>
-        <apache.tiles.version>2.2.2</apache.tiles.version>
-        <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version>
+        <spring.data.jpa.version>1.8.0.RELEASE</spring.data.jpa.version> <!-- 1.7.2.RELEASE -->
+        <spring.data.rest.webmvc.version>2.3.0.RELEASE</spring.data.rest.webmvc.version> <!-- 2.2.2.RELEASE -->
+        <apache.tiles.version>2.2.2</apache.tiles.version> <!--3.0.5-->
+        <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version> <!--1.0.1.Final-->
         <hibernate-validator.version>5.1.3.Final</hibernate-validator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
-        <guava.version>18.0</guava.version>
+        <guava.version>18.0</guava.version> <!-- 17.0 -->
         <commons-lang3.version>3.3.2</commons-lang3.version>
-        <commons-collections4.version>4.0</commons-collections4.version>
+        <commons-collections4.version>4.0</commons-collections4.version> <!-- none -->
         <commons-fileupload.version>1.3.1</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
-        <imgscalr-lib.version>4.2</imgscalr-lib.version>
-        <joda-time.version>2.3</joda-time.version>
-        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <javax.servlet.jsp-api.version>2.3.1</javax.servlet.jsp-api.version>
+        <imgscalr-lib.version>4.2</imgscalr-lib.version> <!-- none -->
+        <joda-time.version>2.3</joda-time.version> <!-- 2.5 -->
+        <javax.servlet-api.version>3.1.0</javax.servlet-api.version> <!-- 3.0.1 -->
+        <javax.servlet.jsp-api.version>2.3.1</javax.servlet.jsp-api.version> <!-- 2.2.1 -->
         <jstl.version>1.2</jstl.version>
-        <tika-core.version>1.4</tika-core.version>
-        <ehcache-web.version>2.0.4</ehcache-web.version>
-        <collections-generic.version>4.01</collections-generic.version>
+        <tika-core.version>1.4</tika-core.version> <!-- none -->
+        <ehcache-web.version>2.0.4</ehcache-web.version> <!-- none, only ehcache 2.8.5, ehcache-core 2.6.10 -->
+        <collections-generic.version>4.01</collections-generic.version><!-- none -->
         <javassist.version>3.18.1-GA</javassist.version>
-        <hibernate-entitymanager.version>4.3.6.Final</hibernate-entitymanager.version>
-        <usertype.jadira.version>3.2.0.GA</usertype.jadira.version>
-        <joda-time.hibernate.version>1.3</joda-time.hibernate.version>
-        <jackson.version>2.3.4</jackson.version>
-        <slf4j.version>1.7.7</slf4j.version>
-        <logback.version>1.1.2</logback.version>
+        <hibernate-entitymanager.version>4.3.6.Final</hibernate-entitymanager.version> <!-- 4.3.8.Final -->
+        <usertype.jadira.version>3.2.0.GA</usertype.jadira.version><!-- none -->
+        <joda-time.hibernate.version>1.3</joda-time.hibernate.version><!-- none -->
+        <jackson.version>2.3.4</jackson.version> <!-- 2.4.5 -->
+        <slf4j.version>1.7.7</slf4j.version> <!-- 1.7.11 -->
+        <logback.version>1.1.2</logback.version> <!-- 1.1.3 -->
         <junit.version>4.11</junit.version>
         <easymock.version>3.2</easymock.version>
     </properties>


### PR DESCRIPTION
This is a first step in order to migrate to the usage of the platform-bom, re #185

@max-dev , versions need to be updated, module by module, and this should be something that you could do best, as you know the code.

Note that @bfcapell has contributed code-updates for spring.data.rest 2.3.0, whereas the current spring-platform (1.1.2) uses 2.2.2. This would be the one point (beside spring.data.jpa) which could bring problems.

If everything goes wrong, the possibly the way to go would be to leave the 2.3.0 code untouched, and to update everything towards spring-platform 2.0.0 (which contains spring-data-rest 2.3.0)