### PR TITLE
added lightadmin-boot example, made it work

### DIFF
--- a/lightadmin-boot/LICENSE
+++ b/lightadmin-boot/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/lightadmin-boot/README.md
+++ b/lightadmin-boot/README.md
@@ -1,0 +1,13 @@
+LightAdmin and Spring Boot integration example
+
+This application is a usual spring-boot application, where lightadmin was added.
+Applying this to your own, existent project/applications means:
+
+* add lightadmin, tomcat and jasper to your pom
+* add some lightadmin init code in (or around) your main code
+
+It is really trivial.
+
+Note: the ideal (and spring-boot like) solution would be to simply add a
+`spring-boot-starter-lightadmin` to your POM. We are aware of this, but it's not
+yet implemented.

--- a/lightadmin-boot/pom.xml
+++ b/lightadmin-boot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.2.3.BUILD-SNAPSHOT</version>
+        <version>1.2.3.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -25,6 +25,15 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <springloaded.version>1.2.0.RELEASE</springloaded.version>
+
+        <!-- Override Spring Boot Versions -->
+
+        <!-- can be outcommented, then tomcat7 is used -->
+        <tomcat.version>8.0.8</tomcat.version>
+
+        <!-- next sets <spring.data.jpa.version>1.8.0.RELEASE & <spring.data.rest.webmvc.version>2.3.0.RELEASE -->
+        <spring-data-releasetrain.version>Fowler-RELEASE</spring-data-releasetrain.version>
+
     </properties>
 
     <dependencies>

--- a/lightadmin-boot/pom.xml
+++ b/lightadmin-boot/pom.xml
@@ -1,0 +1,122 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.2.3.BUILD-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>org.lightadmin</groupId>
+    <artifactId>lightadmin-springboot</artifactId>
+
+    <!--  Please change packaging to "war" for deploying as a web module to servlet container  -->
+    <packaging>jar</packaging>
+    <name>LightAdmin Spring Boot</name>
+    <version>1.1.0.BUILD-SNAPSHOT</version>
+    <description>Spring Boot Integration Sample</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <springloaded.version>1.2.0.RELEASE</springloaded.version>
+    </properties>
+
+    <dependencies>
+        <!-- this dependency is the only lightadmin specific -->
+        <dependency>
+            <groupId>org.lightadmin</groupId>
+            <artifactId>lightadmin</artifactId>
+            <version>1.1.0.BUILD-SNAPSHOT</version>
+        </dependency>
+
+        <!-- standard spring-boot and application dependencies -->
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <!--  Please change scope to "provided" for deploying as a web module to servlet container  -->
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-jasper</artifactId>
+            <!--  Please change scope to "provided" for deploying as a web module to servlet container  -->
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>lightadmin-boot</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>springloaded</artifactId>
+                        <version>${springloaded.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <jvmArguments>
+                        -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
+                    </jvmArguments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>lightadmin-nexus-releases</id>
+            <url>http://lightadmin.org/nexus/content/repositories/releases</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+        </repository>
+        <repository>
+            <id>lightadmin-nexus-snapshots</id>
+            <url>http://lightadmin.org/nexus/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+
+</project>

--- a/lightadmin-boot/src/main/java/org/lightadmin/boot/LightAdminBootApplication.java
+++ b/lightadmin-boot/src/main/java/org/lightadmin/boot/LightAdminBootApplication.java
@@ -1,0 +1,63 @@
+package org.lightadmin.boot;
+
+import org.lightadmin.api.config.LightAdmin;
+import org.lightadmin.core.config.LightAdminWebApplicationInitializer;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.embedded.ServletContextInitializer;
+import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+
+@Configuration
+@ComponentScan
+@EnableAutoConfiguration
+@Order(HIGHEST_PRECEDENCE)
+public class LightAdminBootApplication extends SpringBootServletInitializer {
+
+    /* Please uncomment for deploying as a web module to servlet container */
+    /**
+     * public void onStartup(ServletContext servletContext) throws ServletException {
+     * LightAdmin.configure(servletContext)
+     * .basePackage("org.lightadmin.boot.administration")
+     * .baseUrl("/admin")
+     * .security(false)
+     * .backToSiteUrl("http://lightadmin.org");
+     * super.onStartup(servletContext);
+     * }
+     */
+
+    /* Used for running in "embedded" mode */
+    @Bean
+    public ServletContextInitializer servletContextInitializer() {
+        return new ServletContextInitializer() {
+            @Override
+            public void onStartup(ServletContext servletContext) throws ServletException {
+                LightAdmin.configure(servletContext)
+                        .basePackage("org.lightadmin.boot.administration")
+                        .baseUrl("/admin")
+                        .security(false)
+                        .backToSiteUrl("http://lightadmin.org");
+
+                new LightAdminWebApplicationInitializer().onStartup(servletContext);
+            }
+        };
+    }
+
+    public static void main(String[] args) throws Exception {
+        SpringApplication.run(LightAdminBootApplication.class, args);
+    }
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        return application.sources(LightAdminBootApplication.class);
+    }
+}

--- a/lightadmin-boot/src/main/java/org/lightadmin/boot/administration/CityAdministration.java
+++ b/lightadmin-boot/src/main/java/org/lightadmin/boot/administration/CityAdministration.java
@@ -1,0 +1,14 @@
+package org.lightadmin.boot.administration;
+
+import org.lightadmin.api.config.AdministrationConfiguration;
+import org.lightadmin.api.config.builder.EntityMetadataConfigurationUnitBuilder;
+import org.lightadmin.api.config.unit.EntityMetadataConfigurationUnit;
+import org.lightadmin.boot.domain.City;
+
+public class CityAdministration extends AdministrationConfiguration<City> {
+
+    @Override
+    public EntityMetadataConfigurationUnit configuration(EntityMetadataConfigurationUnitBuilder configurationBuilder) {
+        return configurationBuilder.nameField("name").singularName("City").pluralName("Cities").build();
+    }
+}

--- a/lightadmin-boot/src/main/java/org/lightadmin/boot/administration/HotelAdministration.java
+++ b/lightadmin-boot/src/main/java/org/lightadmin/boot/administration/HotelAdministration.java
@@ -1,0 +1,14 @@
+package org.lightadmin.boot.administration;
+
+import org.lightadmin.api.config.AdministrationConfiguration;
+import org.lightadmin.api.config.builder.EntityMetadataConfigurationUnitBuilder;
+import org.lightadmin.api.config.unit.EntityMetadataConfigurationUnit;
+import org.lightadmin.boot.domain.Hotel;
+
+public class HotelAdministration extends AdministrationConfiguration<Hotel> {
+
+    @Override
+    public EntityMetadataConfigurationUnit configuration(EntityMetadataConfigurationUnitBuilder configurationBuilder) {
+        return configurationBuilder.nameField("name").singularName("Hotel").pluralName("Hotels").build();
+    }
+}

--- a/lightadmin-boot/src/main/java/org/lightadmin/boot/domain/City.java
+++ b/lightadmin-boot/src/main/java/org/lightadmin/boot/domain/City.java
@@ -1,0 +1,70 @@
+package org.lightadmin.boot.domain;
+
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.io.Serializable;
+
+@Entity
+public class City implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column
+    @NotBlank
+    private String name;
+
+    @Column
+    @NotBlank
+    private String state;
+
+    @Column
+    @NotBlank
+    private String country;
+
+    @Column
+    @NotBlank
+    private String map;
+
+    public City() {
+    }
+
+    public City(String name, String country) {
+        super();
+        this.name = name;
+        this.country = country;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getState() {
+        return this.state;
+    }
+
+    public String getCountry() {
+        return this.country;
+    }
+
+    public String getMap() {
+        return this.map;
+    }
+
+    @Override
+    public String toString() {
+        return getName() + "," + getState() + "," + getCountry();
+    }
+}

--- a/lightadmin-boot/src/main/java/org/lightadmin/boot/domain/Hotel.java
+++ b/lightadmin-boot/src/main/java/org/lightadmin/boot/domain/Hotel.java
@@ -1,0 +1,61 @@
+package org.lightadmin.boot.domain;
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+@Entity
+public class Hotel implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @NotNull
+    @ManyToOne
+    private City city;
+
+    @NotBlank
+    @Column
+    private String name;
+
+    @NotBlank
+    @Column
+    private String address;
+
+    @NotBlank
+    @Column
+    private String zip;
+
+    public Hotel() {
+    }
+
+    public Hotel(City city, String name) {
+        this.city = city;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public City getCity() {
+        return this.city;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getAddress() {
+        return this.address;
+    }
+
+    public String getZip() {
+        return this.zip;
+    }
+}

--- a/lightadmin-boot/src/main/java/org/lightadmin/boot/repository/HotelRepository.java
+++ b/lightadmin-boot/src/main/java/org/lightadmin/boot/repository/HotelRepository.java
@@ -1,0 +1,10 @@
+package org.lightadmin.boot.repository;
+
+import org.lightadmin.boot.domain.Hotel;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public interface HotelRepository extends PagingAndSortingRepository<Hotel, Long> {
+
+}

--- a/lightadmin-boot/src/main/java/org/lightadmin/boot/web/ApplicationController.java
+++ b/lightadmin-boot/src/main/java/org/lightadmin/boot/web/ApplicationController.java
@@ -1,0 +1,21 @@
+package org.lightadmin.boot.web;
+
+import org.lightadmin.boot.repository.HotelRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class ApplicationController {
+
+    @Autowired
+    private HotelRepository hotelRepository;
+
+    @RequestMapping("/")
+    public String thymeleafIndexPage(Model model) {
+        model.addAttribute("hotels", hotelRepository.findAll());
+        return "index";
+    }
+}

--- a/lightadmin-boot/src/main/resources/application.properties
+++ b/lightadmin-boot/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+security.basic.enabled=false

--- a/lightadmin-boot/src/main/resources/import.sql
+++ b/lightadmin-boot/src/main/resources/import.sql
@@ -1,0 +1,65 @@
+--
+-- Sample dataset containing a number of Hotels in various Cities across the world.
+--
+
+-- =================================================================================================
+-- AUSTRALIA
+
+-- Brisbane
+insert into city(country, name, state, map) values ('Australia', 'Brisbane', 'Queensland', '-27.470933, 153.023502')
+insert into hotel(city_id, name, address, zip) values (1, 'Conrad Treasury Place', 'William & George Streets', '4001')
+
+-- Melbourne
+insert into city(country, name, state, map) values ('Australia', 'Melbourne', 'Victoria', '-37.813187, 144.96298')
+insert into hotel(city_id, name, address, zip) values (2, 'The Langham', '1 Southgate Ave, Southbank', '3006')
+
+-- Sydney
+insert into city(country, name, state, map) values ('Australia', 'Sydney', 'New South Wales', '-33.868901, 151.207091')
+insert into hotel(city_id, name, address, zip) values (3, 'Swissotel', '68 Market Street', '2000')
+
+
+-- =================================================================================================
+-- CANADA
+
+-- Montreal
+insert into city(country, name, state, map) values ('Canada', 'Montreal', 'Quebec', '45.508889, -73.554167')
+insert into hotel(city_id, name, address, zip) values (4, 'Ritz Carlton', '1228 Sherbrooke St', 'H3G1H6')
+
+
+-- =================================================================================================
+-- ISRAEL
+
+-- Tel Aviv
+insert into city(country, name, state, map) values ('Israel', 'Tel Aviv', '', '32.066157, 34.777821')
+insert into hotel(city_id, name, address, zip) values (5, 'Hilton Tel Aviv', 'Independence Park', '63405')
+
+
+-- =================================================================================================
+-- JAPAN
+
+-- Tokyo
+insert into city(country, name, state, map) values ('Japan', 'Tokyo', '', '35.689488, 139.691706')
+insert into hotel(city_id, name, address, zip) values (6, 'InterContinental Tokyo Bay', 'Takeshiba Pier', '105')
+
+
+-- =================================================================================================
+-- SPAIN
+
+-- Barcelona
+insert into city(country, name, state, map) values ('Spain', 'Barcelona', 'Catalunya', '41.387917, 2.169919')
+insert into hotel(city_id, name, address, zip) values (7, 'Hilton Diagonal Mar', 'Passeig del Taulat 262-264', '08019')
+
+-- =================================================================================================
+-- SWITZERLAND
+
+-- Neuchatel
+insert into city(country, name, state, map) values ('Switzerland', 'Neuchatel', '', '46.992979, 6.931933')
+insert into hotel(city_id, name, address, zip) values (8, 'Hotel Beaulac', ' Esplanade Leopold-Robert 2', '2000')
+
+
+-- =================================================================================================
+-- UNITED KINGDOM
+
+-- Bath
+insert into city(country, name, state, map) values ('UK', 'Bath', 'Somerset', '51.381428, -2.357454')
+insert into hotel(city_id, name, address, zip) values (9, 'The Bath Priory Hotel', 'Weston Road', 'BA1 2XT')

--- a/lightadmin-boot/src/main/resources/logback.xml
+++ b/lightadmin-boot/src/main/resources/logback.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration scan="true">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>utf-8</charset>
+            <Pattern>[%p] %c - %m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <logger name="javax.activation" level="WARN"/>
+    <logger name="org.lightadmin" level="INFO"/>
+    <logger name="ch.qos.logback" level="WARN"/>
+    <logger name="org.apache" level="WARN"/>
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.thymeleaf" level="WARN"/>
+
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/lightadmin-boot/src/main/resources/templates/index.html
+++ b/lightadmin-boot/src/main/resources/templates/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+<head>
+    <title>Spring Boot/Thymeleaf/LightAdmin integration example</title>
+</head>
+<body>
+<h1>Thymeleaf index page</h1>
+
+<p>
+    <em>Simple front-end example using thymeleaf template engine
+        (spring boot standard) and spring mvc to pass repository data to page</em>
+</p>
+
+<table>
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>City</th>
+        <th>Name</th>
+        <th>Address</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="h : ${hotels}">
+        <td th:text="${h.id}">id</td>
+        <td th:text="${h.city}">name</td>
+        <td th:text="${h.name}">icon</td>
+        <td th:text="${h.address}">unitaryPrice</td>
+        <td th:text="${h.zip}">description</td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/lightadmin-boot/src/test/java/org/lightadmin/boot/ThymeTest.java
+++ b/lightadmin-boot/src/test/java/org/lightadmin/boot/ThymeTest.java
@@ -1,0 +1,39 @@
+package org.lightadmin.boot;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = LightAdminBootApplication.class)
+@WebAppConfiguration
+@IntegrationTest
+public class ThymeTest {
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Test
+    public void homePageTest() throws Exception {
+        mockMvc.perform(get("/")).andExpect(status().isOk());
+    }
+
+    @Before
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .build();
+    }
+}

--- a/lightadmin-core/pom.xml
+++ b/lightadmin-core/pom.xml
@@ -99,36 +99,49 @@
           http://docs.spring.io/platform/docs/1.1.2.RELEASE/reference/htmlsingle/#appendix-dependency-versions
         -->
 
+        <!-- Same Versions -->
+
         <spring.version>4.1.6.RELEASE</spring.version>
         <spring.security.version>3.2.7.RELEASE</spring.security.version>
-        <spring.data.jpa.version>1.8.0.RELEASE</spring.data.jpa.version> <!-- 1.7.2.RELEASE -->
-        <spring.data.rest.webmvc.version>2.3.0.RELEASE</spring.data.rest.webmvc.version> <!-- 2.2.2.RELEASE -->
-        <apache.tiles.version>2.2.2</apache.tiles.version> <!--3.0.5-->
-        <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version> <!--1.0.1.Final-->
         <hibernate-validator.version>5.1.3.Final</hibernate-validator.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
-        <guava.version>18.0</guava.version> <!-- 17.0 -->
         <commons-lang3.version>3.3.2</commons-lang3.version>
-        <commons-collections4.version>4.0</commons-collections4.version> <!-- none -->
         <commons-fileupload.version>1.3.1</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
-        <imgscalr-lib.version>4.2</imgscalr-lib.version> <!-- none -->
-        <joda-time.version>2.3</joda-time.version> <!-- 2.5 -->
+        <jstl.version>1.2</jstl.version>
+        <javassist.version>3.18.1-GA</javassist.version>
+        <junit.version>4.11</junit.version>
+
+        <!-- LA  has Newer Versions -->
+
+        <spring.data.jpa.version>1.8.0.RELEASE</spring.data.jpa.version> <!-- 1.7.2.RELEASE -->
+        <spring.data.rest.webmvc.version>2.3.0.RELEASE</spring.data.rest.webmvc.version> <!-- 2.2.2.RELEASE -->
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version> <!-- 3.0.1 -->
         <javax.servlet.jsp-api.version>2.3.1</javax.servlet.jsp-api.version> <!-- 2.2.1 -->
-        <jstl.version>1.2</jstl.version>
-        <tika-core.version>1.4</tika-core.version> <!-- none -->
-        <ehcache-web.version>2.0.4</ehcache-web.version> <!-- none, only ehcache 2.8.5, ehcache-core 2.6.10 -->
-        <collections-generic.version>4.01</collections-generic.version><!-- none -->
-        <javassist.version>3.18.1-GA</javassist.version>
+        <guava.version>18.0</guava.version> <!-- 17.0 -->
+
+        <!-- LA has Older Version -->
+
+        <apache.tiles.version>2.2.2</apache.tiles.version> <!--3.0.5-->
+        <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version> <!--1.0.1.Final-->
+        <joda-time.version>2.3</joda-time.version> <!-- 2.5 -->
         <hibernate-entitymanager.version>4.3.6.Final</hibernate-entitymanager.version> <!-- 4.3.8.Final -->
-        <usertype.jadira.version>3.2.0.GA</usertype.jadira.version><!-- none -->
-        <joda-time.hibernate.version>1.3</joda-time.hibernate.version><!-- none -->
         <jackson.version>2.3.4</jackson.version> <!-- 2.4.5 -->
         <slf4j.version>1.7.7</slf4j.version> <!-- 1.7.11 -->
         <logback.version>1.1.2</logback.version> <!-- 1.1.3 -->
-        <junit.version>4.11</junit.version>
-        <easymock.version>3.2</easymock.version>
+
+
+        <!-- not included within spring-platform 1.1.2 -->
+        <commons-collections4.version>4.0</commons-collections4.version> <!-- none -->
+        <imgscalr-lib.version>4.2</imgscalr-lib.version> <!-- none -->
+        <tika-core.version>1.4</tika-core.version> <!-- none -->
+        <ehcache-web.version>2.0.4</ehcache-web.version> <!-- none, only ehcache 2.8.5, ehcache-core 2.6.10 -->
+        <collections-generic.version>4.01</collections-generic.version><!-- none -->
+        <usertype.jadira.version>3.2.0.GA</usertype.jadira.version><!-- none -->
+        <joda-time.hibernate.version>1.3</joda-time.hibernate.version><!-- none -->
+        <easymock.version>3.2</easymock.version><!-- none -->
+
+
     </properties>
 
     <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>lightadmin-core</module>
         <module>lightadmin-sandbox</module>
         <module>lightadmin-tests</module>
+        <module>lightadmin-boot</module>
     </modules>
 
 </project>


### PR DESCRIPTION
**this works now with spring-boot-1.2.3**

this branch can be used to simply stabilize spring-data-rest-2.3.0, and try to run it on the actual version of spring-boot (1.2.3), without any changes towards using spring-platform.

(there are 2 more branches in my repo, can you please pull them, I cannot create new branches here myself)

https://github.com/lazaridis-com/light-admin/tree/spring-platform-1.1.2

https://github.com/lazaridis-com/light-admin/tree/spring-platform-2.0.0

(the lightadmin-boot module should stay within the code)