### PR TITLE
Update definitions.xml

### DIFF
--- a/lightadmin-core/src/main/resources/META-INF/tiles/definitions.xml
+++ b/lightadmin-core/src/main/resources/META-INF/tiles/definitions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 2.1//EN"
-        "http://tiles.apache.org/dtds/tiles-config_2_1.dtd">
+<!DOCTYPE tiles-definitions PUBLIC "-//Apache Software Foundation//DTD Tiles Configuration 3.0//EN"
+        "http://tiles.apache.org/dtds/tiles-config_3_0.dtd">
 
 <tiles-definitions>
 


### PR DESCRIPTION
if use tile 2.1 then lightadmin-demo cannot load the definition.xml because lightadmin use tiles3.TilesConfigurer.