### PR TITLE
Upgrade Apache Commons Collections to v4.1

### DIFF
--- a/lightadmin-core/pom.xml
+++ b/lightadmin-core/pom.xml
@@ -97,7 +97,7 @@
 
         <spring.platform.version>1.1.2.RELEASE</spring.platform.version>
 
-        <commons-collections4.version>4.0</commons-collections4.version>
+        <commons-collections4.version>4.1</commons-collections4.version>
         <imgscalr-lib.version>4.2</imgscalr-lib.version>
         <tika-core.version>1.4</tika-core.version>
         <ehcache-web.version>2.0.4</ehcache-web.version>


### PR DESCRIPTION
Version 4.0 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/