### PR TITLE
Upgrade to Spring 2.0.5

### DIFF
--- a/lightadmin-core/pom.xml
+++ b/lightadmin-core/pom.xml
@@ -95,7 +95,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
 
-        <spring.platform.version>1.1.2.RELEASE</spring.platform.version>
+        <spring.platform.version>2.0.5.RELEASE</spring.platform.version>
 
         <commons-collections4.version>4.0</commons-collections4.version>
         <imgscalr-lib.version>4.2</imgscalr-lib.version>

--- a/lightadmin-core/src/main/java/org/lightadmin/core/config/bootstrap/JpaMetamodelMappingContextFactoryBean.java
+++ b/lightadmin-core/src/main/java/org/lightadmin/core/config/bootstrap/JpaMetamodelMappingContextFactoryBean.java
@@ -22,6 +22,8 @@ import org.springframework.util.Assert;
 import javax.persistence.EntityManager;
 import javax.persistence.metamodel.ManagedType;
 import javax.persistence.metamodel.Metamodel;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -50,7 +52,8 @@ public class JpaMetamodelMappingContextFactoryBean extends AbstractFactoryBean<J
             }
         }
 
-        JpaMetamodelMappingContext context = new JpaMetamodelMappingContext(metamodel);
+        Set<Metamodel> metaModelSet = new HashSet<>(Collections.singletonList(metamodel));
+        JpaMetamodelMappingContext context = new JpaMetamodelMappingContext(metaModelSet);
         context.setInitialEntitySet(entitySources);
         context.initialize();
 

--- a/lightadmin-core/src/main/java/org/lightadmin/core/config/context/LightAdminRepositoryRestMvcConfiguration.java
+++ b/lightadmin-core/src/main/java/org/lightadmin/core/config/context/LightAdminRepositoryRestMvcConfiguration.java
@@ -33,9 +33,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.repository.support.RepositoryInvokerFactory;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.core.event.ValidatingRepositoryEventListener;
-import org.springframework.data.rest.core.invoke.RepositoryInvokerFactory;
 import org.springframework.data.rest.core.support.DomainObjectMerger;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.data.rest.webmvc.config.PersistentEntityResourceAssemblerArgumentResolver;
@@ -44,6 +44,7 @@ import org.springframework.validation.Validator;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
+import java.net.URI;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newLinkedList;
@@ -113,7 +114,7 @@ public class LightAdminRepositoryRestMvcConfiguration extends RepositoryRestMvcC
     @Override
     protected void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
         config.setDefaultPageSize(10);
-        config.setBaseUri(lightAdminConfiguration().getApplicationRestBaseUrl());
+        config.setBasePath(lightAdminConfiguration().getApplicationRestBaseUrl().toString());
         config.exposeIdsFor(globalAdministrationConfiguration().getAllDomainTypesAsArray());
         config.setReturnBodyOnCreate(true);
         config.setReturnBodyOnUpdate(true);

--- a/lightadmin-core/src/main/java/org/lightadmin/core/config/context/LightAdminSecurityConfiguration.java
+++ b/lightadmin-core/src/main/java/org/lightadmin/core/config/context/LightAdminSecurityConfiguration.java
@@ -63,10 +63,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import javax.servlet.Filter;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newLinkedHashMap;
@@ -109,7 +106,7 @@ public class LightAdminSecurityConfiguration {
     public Filter filterSecurityInterceptor(AuthenticationManager authenticationManager) throws Exception {
         FilterSecurityInterceptor filter = new FilterSecurityInterceptor();
         filter.setAuthenticationManager(authenticationManager);
-        filter.setAccessDecisionManager(new AffirmativeBased(asList((AccessDecisionVoter) new RoleVoter())));
+        filter.setAccessDecisionManager(new AffirmativeBased(Arrays.<AccessDecisionVoter<? extends Object>>asList((AccessDecisionVoter<Object>) new RoleVoter())));
         filter.setSecurityMetadataSource(securityMetadataSource());
         filter.afterPropertiesSet();
         return filter;

--- a/lightadmin-core/src/main/java/org/lightadmin/core/persistence/repository/invoker/DynamicRepositoryInvoker.java
+++ b/lightadmin-core/src/main/java/org/lightadmin/core/persistence/repository/invoker/DynamicRepositoryInvoker.java
@@ -19,7 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.rest.core.invoke.RepositoryInvoker;
+import org.springframework.data.repository.support.RepositoryInvoker;
 
 import java.util.List;
 

--- a/lightadmin-core/src/main/java/org/lightadmin/core/persistence/repository/invoker/DynamicRepositoryInvokerFactory.java
+++ b/lightadmin-core/src/main/java/org/lightadmin/core/persistence/repository/invoker/DynamicRepositoryInvokerFactory.java
@@ -17,8 +17,8 @@ package org.lightadmin.core.persistence.repository.invoker;
 
 import org.lightadmin.core.persistence.repository.DynamicJpaRepository;
 import org.springframework.data.repository.support.Repositories;
-import org.springframework.data.rest.core.invoke.RepositoryInvoker;
-import org.springframework.data.rest.core.invoke.RepositoryInvokerFactory;
+import org.springframework.data.repository.support.RepositoryInvoker;
+import org.springframework.data.repository.support.RepositoryInvokerFactory;
 
 public class DynamicRepositoryInvokerFactory implements RepositoryInvokerFactory {
 

--- a/lightadmin-core/src/main/java/org/lightadmin/core/persistence/repository/invoker/DynamicRepositoryInvokerWrapper.java
+++ b/lightadmin-core/src/main/java/org/lightadmin/core/persistence/repository/invoker/DynamicRepositoryInvokerWrapper.java
@@ -20,7 +20,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.rest.core.invoke.RepositoryInvoker;
+import org.springframework.data.repository.support.RepositoryInvoker;
+import org.springframework.util.MultiValueMap;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
@@ -94,18 +95,8 @@ public class DynamicRepositoryInvokerWrapper implements DynamicRepositoryInvoker
     }
 
     @Override
-    public boolean exposesSave() {
-        return repositoryInvoker.exposesSave();
-    }
-
-    @Override
     public boolean hasDeleteMethod() {
         return repositoryInvoker.hasDeleteMethod();
-    }
-
-    @Override
-    public boolean exposesDelete() {
-        return repositoryInvoker.exposesDelete();
     }
 
     @Override
@@ -114,17 +105,12 @@ public class DynamicRepositoryInvokerWrapper implements DynamicRepositoryInvoker
     }
 
     @Override
-    public boolean exposesFindOne() {
-        return repositoryInvoker.exposesFindOne();
-    }
-
-    @Override
     public boolean hasFindAllMethod() {
         return repositoryInvoker.hasFindAllMethod();
     }
 
     @Override
-    public boolean exposesFindAll() {
-        return repositoryInvoker.exposesFindAll();
+    public Object invokeQueryMethod(Method method, MultiValueMap<String, ? extends Object> multiValueMap, Pageable pageable, Sort sort) {
+        return repositoryInvoker.invokeQueryMethod(method, multiValueMap, pageable, sort);
     }
 }

--- a/lightadmin-core/src/main/java/org/lightadmin/core/web/RepositoryFilePropertyController.java
+++ b/lightadmin-core/src/main/java/org/lightadmin/core/web/RepositoryFilePropertyController.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
-import org.springframework.data.rest.core.invoke.RepositoryInvoker;
+import org.springframework.data.repository.support.RepositoryInvoker;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.data.rest.webmvc.RootResourceInformation;

--- a/lightadmin-core/src/main/java/org/lightadmin/core/web/support/DynamicPersistentEntityResourceAssembler.java
+++ b/lightadmin-core/src/main/java/org/lightadmin/core/web/support/DynamicPersistentEntityResourceAssembler.java
@@ -16,6 +16,7 @@
 package org.lightadmin.core.web.support;
 
 import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.repository.core.EntityInformation;
 import org.springframework.data.repository.support.Repositories;
 import org.springframework.data.rest.core.mapping.ResourceMappings;
@@ -37,7 +38,7 @@ import static org.springframework.beans.PropertyAccessorFactory.forDirectFieldAc
 public class DynamicPersistentEntityResourceAssembler extends PersistentEntityResourceAssembler {
 
     public DynamicPersistentEntityResourceAssembler(PersistentEntityResourceAssembler resourceAssembler) {
-        super(repositories(resourceAssembler), entityLinks(resourceAssembler), projector(resourceAssembler), mappings(resourceAssembler));
+        super(entities(resourceAssembler), entityLinks(resourceAssembler), projector(resourceAssembler), mappings(resourceAssembler));
     }
 
     /**
@@ -66,7 +67,12 @@ public class DynamicPersistentEntityResourceAssembler extends PersistentEntityRe
         return entityLinks(this).linkToSingleResource(entity.getType(), id).withSelfRel();
     }
 
+    private static PersistentEntities entities(PersistentEntityResourceAssembler persistentEntityResourceAssembler) {
+      return (PersistentEntities) forDirectFieldAccess(persistentEntityResourceAssembler).getPropertyValue("entities");
+    }
+
     private static Repositories repositories(PersistentEntityResourceAssembler persistentEntityResourceAssembler) {
+        //TODO: Repositories are no longer available!
         return (Repositories) forDirectFieldAccess(persistentEntityResourceAssembler).getPropertyValue("repositories");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
 
-        <spring.platform.version>1.1.2.RELEASE</spring.platform.version>
+        <spring.platform.version>2.0.5.RELEASE</spring.platform.version>
         <jstl.version>1.2</jstl.version>
 
         <light-logging-configurer.version>1.0.0.BUILD-SNAPSHOT</light-logging-configurer.version>


### PR DESCRIPTION
Current light-admin version is incompatible with recent Spring releases (eg. Spring Boot 1.3.0). The pull requests allows building light-admin with the newest Spring release. 

A problem remains in `DynamicPersistentEntityResourceAssembler` as repositories seem to be unsupported nowadays. There is yet to be a fix found for this.